### PR TITLE
Only install required dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,27 +34,27 @@
     "parcel-bundler": "^1.12.4"
   },
   "dependencies": {
+    "replace-in-file": "^6.1.0",
+    "workbox-build": "^6.0.2"
+  },
+  "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
+    "@commitlint/cli": "^11.0.0",
+    "@commitlint/config-conventional": "^11.0.0",
+    "commitizen": "^4.2.2",
+    "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.17.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "npm-run-all": "^4.1.5",
-    "replace-in-file": "^6.1.0",
-    "semantic-release": "^17.3.1",
-    "workbox-build": "^6.0.2"
-  },
-  "devDependencies": {
-    "@commitlint/cli": "^11.0.0",
-    "@commitlint/config-conventional": "^11.0.0",
-    "commitizen": "^4.2.2",
-    "cz-conventional-changelog": "^3.3.0",
     "husky": "^4.3.6",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
     "prettier-plugin-package": "^1.3.0",
-    "pretty-quick": "^3.1.0"
+    "pretty-quick": "^3.1.0",
+    "semantic-release": "^17.3.1"
   },
   "types": "index.d.ts"
 }


### PR DESCRIPTION
Thanks for writing this plugin; the other parcel plugins for workbox don't really support injectManifest very well.

Most of the dependencies in your package.json don't need to be installed by the end-user. This commit just moves them over to devDependencies.

This reduces the amount of packages installed from 900+ to just under 80.

![image](https://user-images.githubusercontent.com/3804041/107316164-5540b300-6a55-11eb-9653-0c12085a3f78.png)
![image](https://user-images.githubusercontent.com/3804041/107316173-596cd080-6a55-11eb-8634-cbaab553851c.png)
